### PR TITLE
Fix whitespace in tcf snippet

### DIFF
--- a/snippets/javascript/flow-try-catch-finally.snippets
+++ b/snippets/javascript/flow-try-catch-finally.snippets
@@ -1,9 +1,9 @@
 snippet tcf
-    try {
-        ${1}
-    } catch (${2:err}) {
-        ${3}
-    } finally {
-        ${0}
-    }
+	try {
+		${1}
+	} catch (${2:err}) {
+		${3}
+	} finally {
+		${0}
+	}
 


### PR DESCRIPTION
`tcf` snippet uses spaces instead of tabs, causing errors when used with UltiSnips.
