### PR TITLE
Add ES6 snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,18 @@ function* (${1}) {
 }
 ```
 
+## Variables
+
+### [const] const
+```
+const ${1} = ${0}
+```
+
+### [let] let
+```javascript
+let ${1} = ${0}
+```
+
 ## JSON
 
 ### [jp] json parse
@@ -311,6 +323,22 @@ ${1:array}.forEach((${2:item}) => {
 ```javascript
 while (${1:condition}) {
 	${0}
+}
+```
+
+## Class
+
+### [cla] class definition
+```javascript
+class ${1} {
+		${0}
+}
+```
+
+### [clex] class definition with extends 
+```javascript
+class ${1} extends ${2} {
+		${0}
 }
 ```
 

--- a/snippets/javascript/class-definition.snippet
+++ b/snippets/javascript/class-definition.snippet
@@ -1,0 +1,4 @@
+snippet cla
+	class ${1} {
+		${0}
+	}

--- a/snippets/javascript/class-extends.snippet
+++ b/snippets/javascript/class-extends.snippet
@@ -1,0 +1,5 @@
+snippet clex
+	class ${1} extends ${2} {
+		${0}
+	}
+

--- a/snippets/javascript/const-definition.snippet
+++ b/snippets/javascript/const-definition.snippet
@@ -1,0 +1,2 @@
+snippet const
+	const ${1} = ${0}

--- a/snippets/javascript/let-definition.snippet
+++ b/snippets/javascript/let-definition.snippet
@@ -1,0 +1,2 @@
+snippet let
+	let ${1} = ${0}


### PR DESCRIPTION
This PR adds snippets for `let`, `const`, `class` and `class foo extends bar` and updates the README accordingly.
