### PR TITLE
Correction in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ for (let i = 0 i < ${1:length} i++) {
 ### [forin] for in
 ```javascript
 for (${1:prop} in ${2:obj}) {
-	if (${2:obj}.hasOwnProperty(${1:prop})) {
+	if ($2.hasOwnProperty($1)) {
 		${0}
 	}
 }

--- a/snippets/javascript/loop-for-in.snippets
+++ b/snippets/javascript/loop-for-in.snippets
@@ -1,6 +1,6 @@
 snippet forin
 	for (${1:prop} in ${2:obj}) {
-		if (${2:obj}.hasOwnProperty(${1:prop})) {
+		if ($2.hasOwnProperty($1)) {
 			${0}
 		}
 	}


### PR DESCRIPTION
The example shows wrong format for snippet. Once `${1:prop}` has been used the variable should be referred as `$1` in later snippets code. 